### PR TITLE
DRAFT: Android Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,77 @@
 
 ## 🎯 About
 
-This is a react native application for controlling rewheel-flashed boards that have been modified using the rewheel app.
+This is a react native application for controlling OneWheel boards.
+
+**Important Note**: There are certain additional steps that must be taken to be able to use Custom Shaping on Pint boards. *Those steps are left up to the you, the user!* Good luck!
 
 
-*It is not affiliated in any way with the actual ReWheel project, or Future Motion.*
+**Important Note 2**: This project is not, in **any** way, affiliated with Future Motion.
 
 
 ## 🚦 Getting Started
 
 ### Required Software
 
-- [NodeJS](https://nodejs.org/en)
-- XCode (for ios)
+- [NodeJS](https://nodejs.org/en); [nvm](https://github.com/nvm-sh/nvm) is highly recommended.
+- [XCode](https://developer.apple.com/xcode/) (for iOS)
 - [Android Command-Line Tools](https://developer.android.com/studio#command-line-tools-only) (for Android)
 
+### Installing Dependencies
+
 ```bash
-# Clone this project
-git clone https://github.com/tzfx/owrn
-# Access
-cd owrn
-# Install dependencies
-npm install                      # for nodejs
-pushd ios && pod install && popd # for native hooks
-xed -b ios
+git clone https://github.com/tzfx/owrn # Clone
+cd owrn         # Hop into the directory
+npm install     # Install NodeJS dependencies.
+
+### Now, choose your own adventure ###
+npm run ios     # iOS
+                # or
+npm run android # android
 ```
 
-## 📲 Xcode: ##
-### :iphone: Install on iPhone: ###
-Plug in iphone and select your phone as the target in xcode.
-In the product menu select "Build For Running"
-Now enable Developer mode on your iPhone using the following guide: [Enable Developer Mode](https://help.testapp.io/faq/enable-developer-mode-ios/)
+
+## 😭 Troubleshooting Development
+
+Below are some quick troubleshooting for getting things working on iOS and Android.
+
+### 🍏 iOS Troubleshooting
+
+Make sure you have the following installed:
+
+- The latest version of [XCode](https://developer.apple.com/xcode/)
+- Xcode Command-line tools: `xcode-select --install`
+- Ruby >= 2.7.6
+- [Developer Mode](https://help.testapp.io/faq/enable-developer-mode-ios/) enabled on the iPhone you'd like to publish the application to.
+
+#### 🔥 Hot Tips
+
+- Hot Tip: If things aren't compiling right, try to reinstall the react native to ios components with: `cd ios && pod install`.
+- Hot Tip #2: If xcode refuses to open when you do `npm run ios`, try `xed -b ios`. This should load the right workspace.
+- Hot Tip #3: There are two schema in the xcode workspace, `owrn` and `owrn - Release`. The first one is appropriate for development and debugging, the second one is what you want to use to actually use the application on your phone, in a production capacity.
+
+
+### 🤖 Android Troubleshooting
+
+Make sure you have the following installed:
+
+- The latest version of [Java](https://www.java.com/en/download/help/download_options.html)
+- [Android Command-Line Tools](https://developer.android.com/studio#command-line-tools-only), which gives you access to `sdkmanager`.
+- Android platform tools `sdkmanager --install 'platform-tools'`
+- The latest Android sdk: `sdkmanager --install 'platform;android-33'`
+- For sim support, an android system image & g_apis package for your arch: `sdkmanager --install 'system-images;android-33;google_apis;arm64-v8a'`
+
+
+### 📲 Connection Troubleshooting
+
+You may find it difficult to connect to your board. You may have to do the following:
+
+1. Open the official OneWheel application.
+2. Connect to your board.
+3. Disconnect from your board in the application.
+4. Re-open OWRN and connect.
+
+These steps may not be necessary for everyone. 🫠
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Make sure you have the following installed:
 
 #### 🔥 Hot Tips
 
-- Hot Tip: If things aren't compiling right, try to reinstall the react native to ios components with: `cd ios && pod install`.
+- Hot Tip #1: If things aren't compiling right, try to reinstall the react native to ios components with: `cd ios && pod install`.
 - Hot Tip #2: If xcode refuses to open when you do `npm run ios`, try `xed -b ios`. This should load the right workspace.
 - Hot Tip #3: There are two schema in the xcode workspace, `owrn` and `owrn - Release`. The first one is appropriate for development and debugging, the second one is what you want to use to actually use the application on your phone, in a production capacity.
 
@@ -66,6 +66,13 @@ Make sure you have the following installed:
 - The latest Android sdk: `sdkmanager --install 'platform;android-33'`
 - For sim support, an android system image & g_apis package for your arch: `sdkmanager --install 'system-images;android-33;google_apis;arm64-v8a'`
 
+#### 🔥 Hot Tips for on-device Debugging.
+
+- Hot Tip #1: You can make sure that your phone is connected via `adb devices -l`
+- Hot Tip #2: If it isn't there, make sure you [enable developer mode](https://developer.android.com/studio/debug/dev-options) on the phone.
+- Hot Tip #3: If it *still* isn't there, make sure you enable USB Debugging via **Settings > System > Advanced > Developer Options > USB debugging**
+- Hot Tip #4: Permissions are WHACK. If your scanner isn't showing up any devices (or you get the permissions alert), make sure Precise Location is enabled for owrn in system settings.
+- Hot Tip #5: You can build a production artefact and get it on your phone by doing `npm run android -- --mode=release`. This will strip out debug logging and the dependency on metro.
 
 ### 📲 Connection Troubleshooting
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
       but in fact some manufacturers still need it for BLE to properly work :
       https://stackoverflow.com/a/72370969
     -->
-    <uses-permission android:name="android.permission.BLUETOOTH" tools:remove="android:maxSdkVersion" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
     <!--
       should normally only be needed on android < 12 if you want to:
       - activate bluetooth programmatically
@@ -17,10 +17,10 @@
       see: https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#discover-local-devices.
       Same as above, may still be wrongly needed by some manufacturers on android 12+.
      -->
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" tools:remove="android:maxSdkVersion" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- Only when targeting Android 12 or higher -->
     <!--

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" tools:remove="android:maxSdkVersion" />
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28"/>
-    <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
 
     <!-- Only when targeting Android 12 or higher -->
     <!--

--- a/package-lock.json
+++ b/package-lock.json
@@ -13189,9 +13189,9 @@
       }
     },
     "node_modules/react-native-ble-manager": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-ble-manager/-/react-native-ble-manager-10.0.0.tgz",
-      "integrity": "sha512-vSFBzTJ6JfRXW5Hdmxtc4ioUah0lXnnYBzghx59CSCFmmMnMJM/lQ253AMi5tXfqB3LgaZyHvoAzpiqpUkRTXA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-ble-manager/-/react-native-ble-manager-10.0.2.tgz",
+      "integrity": "sha512-6KlaL/fBvAlk11Yt9zlTnZqfdtGLQCECUaX5Y3E+DZ5BE6LmQ4u7Zvy59bM4TdR2a5UcK+8mNK3XWLjke+QfKw==",
       "peerDependencies": {
         "react-native": ">=0.60.0"
       }
@@ -25461,9 +25461,9 @@
       }
     },
     "react-native-ble-manager": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-ble-manager/-/react-native-ble-manager-10.0.0.tgz",
-      "integrity": "sha512-vSFBzTJ6JfRXW5Hdmxtc4ioUah0lXnnYBzghx59CSCFmmMnMJM/lQ253AMi5tXfqB3LgaZyHvoAzpiqpUkRTXA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-ble-manager/-/react-native-ble-manager-10.0.2.tgz",
+      "integrity": "sha512-6KlaL/fBvAlk11Yt9zlTnZqfdtGLQCECUaX5Y3E+DZ5BE6LmQ4u7Zvy59bM4TdR2a5UcK+8mNK3XWLjke+QfKw==",
       "requires": {}
     },
     "react-native-codegen": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import {
   Button,
   NativeEventEmitter,
   NativeModules,
+  PermissionsAndroid,
+  Platform,
   SafeAreaView,
   StatusBar,
   StyleSheet,
@@ -17,12 +19,12 @@ import BleManager, {PeripheralInfo} from 'react-native-ble-manager';
 import Battery from './Battery';
 import BoardHeader from './BoardHeader';
 import ConfigEditor from './ConfigEditor';
-import {ConnectionState} from './util/ConnectionState';
 import ConnectionStatus from './ConnectionStatus';
 import ModeSelection from './ModeSelection';
 import {AppConfig, SavedBoard, StorageService} from './StorageService';
 import Telemetry from './Telemetry';
 import {Themes, Typography} from './Typography';
+import {ConnectionState} from './util/ConnectionState';
 
 import {ONEWHEEL_SERVICE_UUID} from './util/bluetooth';
 const BleManagerModule = NativeModules.BleManager;
@@ -140,16 +142,28 @@ const App = () => {
       setSavedBoards((await StorageService.getSavedBoards()) ?? []);
       setConfig(savedConfig);
       console.debug('Got saved configuration ->', savedConfig);
+      const platform = Platform.OS;
+      if (platform === 'android') {
+        try {
+          // Android BT setup for SDK>23:
+          await PermissionsAndroid.requestMultiple([
+            PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+            PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+          ]);
+        } catch (_err) {} // FIX: Handle if the user denies.
+      }
       await BleManager.start({showAlert: true});
       console.debug('BT Initialized.');
       await new Promise(res => setTimeout(() => res(true), 100));
-      // Required for Android.
-      try {
-        await BleManager.enableBluetooth();
-      } catch (err) {
-        // Unsupported in iOS.
-        if (err !== 'Not supported') {
-          console.error(err);
+      if (platform === 'android') {
+        // Required for Android.
+        try {
+          await BleManager.enableBluetooth();
+        } catch (err) {
+          // Unsupported in iOS.
+          if (err !== 'Not supported') {
+            console.error(err);
+          }
         }
       }
       // Setup disconnection listener.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,10 +146,14 @@ const App = () => {
       if (platform === 'android') {
         try {
           // Android BT setup for SDK>23:
-          await PermissionsAndroid.requestMultiple([
+          const PERM_REQS = await PermissionsAndroid.requestMultiple([
             PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
             PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+            PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
+            PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+            PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION,
           ]);
+          console.debug('BT Permissions Requested (Android)', PERM_REQS);
         } catch (_err) {} // FIX: Handle if the user denies.
       }
       await BleManager.start({showAlert: true});
@@ -159,6 +163,7 @@ const App = () => {
         // Required for Android.
         try {
           await BleManager.enableBluetooth();
+          console.debug('BT Enabled (Android)');
         } catch (err) {
           // Unsupported in iOS.
           if (err !== 'Not supported') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,6 +154,17 @@ const App = () => {
             PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION,
           ]);
           console.debug('BT Permissions Requested (Android)', PERM_REQS);
+          const denied = Object.entries(PERM_REQS).filter(
+            ([_, v]) => v !== 'granted',
+          );
+          if (denied.length > 0) {
+            return Alert.alert(
+              'Missing Permissions',
+              `The following permissions need to be granted in order for bluetooth to work: \n${denied.map(
+                ([k]) => `- ${k}\n`,
+              )}\nPlease review and allow these permissions in Settings.`,
+            );
+          }
         } catch (_err) {} // FIX: Handle if the user denies.
       }
       await BleManager.start({showAlert: true});

--- a/src/BoardHeader.tsx
+++ b/src/BoardHeader.tsx
@@ -6,7 +6,6 @@ import {SavedBoard, StorageService} from './StorageService';
 import {useEffect, useState} from 'react';
 import {Typography} from './Typography';
 import {
-  Button,
   Modal,
   Pressable,
   SafeAreaView,
@@ -49,9 +48,18 @@ const BoardHeader = ({connectedDevice, board, handleSave}: Props) => {
   }, [board]);
 
   return (
-    <SafeAreaView>
+    <View>
       <Modal animationType="slide" visible={editting}>
         <SafeAreaView style={styles.modalContainer}>
+          <View>
+            <Text
+              style={{
+                fontSize: Typography.fontsize.medium,
+                fontWeight: '600',
+              }}>
+              Board Configuration
+            </Text>
+          </View>
           <View style={styles.modalInput}>
             <Text style={styles.modalInputLabel}>Board Name</Text>
             <TextInput
@@ -79,15 +87,29 @@ const BoardHeader = ({connectedDevice, board, handleSave}: Props) => {
                 value={autoconnect}
               />
             </View>
-            <View style={styles.flexRow}>
-              <Button
-                color={'grey'}
-                title="Cancel"
+            <View
+              style={{
+                width: '100%',
+                borderBottomWidth: StyleSheet.hairlineWidth,
+                marginVertical: 20,
+              }}></View>
+            <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'flex-end',
+                width: '100%',
+              }}>
+              <Pressable
                 onPress={() => setEditting(false)}
-              />
-              <Button
-                title="Save"
-                color={Typography.colors.emerald}
+                style={{
+                  paddingHorizontal: 20,
+                  paddingVertical: 10,
+                }}>
+                <Text style={{color: Typography.colors.davys_grey}}>
+                  Cancel
+                </Text>
+              </Pressable>
+              <Pressable
                 onPress={() => {
                   if (connectedDevice) {
                     saveBoard(connectedDevice.id).finally(() =>
@@ -95,44 +117,38 @@ const BoardHeader = ({connectedDevice, board, handleSave}: Props) => {
                     );
                   }
                 }}
-              />
+                style={{
+                  backgroundColor: Typography.colors.emerald,
+                  paddingHorizontal: 20,
+                  paddingVertical: 10,
+                  marginLeft: 10,
+                }}>
+                <Text style={{color: Typography.colors.white}}>Save</Text>
+              </Pressable>
             </View>
           </View>
         </SafeAreaView>
       </Modal>
       <View style={styles.nameContainer}>
-        {/* <View style={styles.flex1} />
-        <Text style={styles.boardName}>
-          {board?.name ?? connectedDevice?.name ?? connectedDevice?.id}
-        </Text> */}
-        <View
+        <Pressable
           style={{
-            ...styles.flex1,
-            flexDirection: 'row',
-            justifyContent: 'center',
-            height: 45,
-          }}>
-          <Pressable style={{height: '100%'}} onPress={() => setEditting(true)}>
-            <Text
-              style={{
-                color: Typography.colors.white,
-                fontSize: Typography.fontsize.large,
-              }}>
-              {(board?.name ?? connectedDevice?.name ?? connectedDevice?.id) +
-                ' ⚙️'}
-            </Text>
-          </Pressable>
-          {/* <Button
-            color={Typography.colors.celadon}
-            title={
-              (board?.name ?? connectedDevice?.name ?? connectedDevice?.id) +
-              ' ⚙️'
-            }
-            onPress={() => setEditting(true)}
-          /> */}
-        </View>
+            backgroundColor: Typography.colors.emerald,
+            width: '100%',
+            paddingVertical: 5,
+          }}
+          onPress={() => setEditting(true)}>
+          <Text
+            style={{
+              textAlign: 'center',
+              color: Typography.colors.white,
+              fontSize: Typography.fontsize.large * 0.85,
+            }}>
+            {(board?.name ?? connectedDevice?.name ?? connectedDevice?.id) +
+              ' ⚙️'}
+          </Text>
+        </Pressable>
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 
@@ -141,9 +157,7 @@ export default BoardHeader;
 const styles = StyleSheet.create({
   nameContainer: {
     flexDirection: 'row',
-    justifyContent: 'flex-end',
-    backgroundColor: Typography.colors.celadon,
-    width: '100%',
+    justifyContent: 'center',
   },
   boardName: {
     fontSize: Typography.fontsize.medium * 1.5,
@@ -156,6 +170,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   modalContainer: {
+    margin: 30,
     flexDirection: 'column',
     height: '100%',
   },

--- a/src/BoardHeader.tsx
+++ b/src/BoardHeader.tsx
@@ -8,6 +8,7 @@ import {Typography} from './Typography';
 import {
   Button,
   Modal,
+  Pressable,
   SafeAreaView,
   StyleSheet,
   Switch,
@@ -100,12 +101,35 @@ const BoardHeader = ({connectedDevice, board, handleSave}: Props) => {
         </SafeAreaView>
       </Modal>
       <View style={styles.nameContainer}>
-        <View style={styles.flex1} />
+        {/* <View style={styles.flex1} />
         <Text style={styles.boardName}>
           {board?.name ?? connectedDevice?.name ?? connectedDevice?.id}
-        </Text>
-        <View style={styles.flex1}>
-          <Button title="✏️" onPress={() => setEditting(true)} />
+        </Text> */}
+        <View
+          style={{
+            ...styles.flex1,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            height: 45,
+          }}>
+          <Pressable style={{height: '100%'}} onPress={() => setEditting(true)}>
+            <Text
+              style={{
+                color: Typography.colors.white,
+                fontSize: Typography.fontsize.large,
+              }}>
+              {(board?.name ?? connectedDevice?.name ?? connectedDevice?.id) +
+                ' ⚙️'}
+            </Text>
+          </Pressable>
+          {/* <Button
+            color={Typography.colors.celadon}
+            title={
+              (board?.name ?? connectedDevice?.name ?? connectedDevice?.id) +
+              ' ⚙️'
+            }
+            onPress={() => setEditting(true)}
+          /> */}
         </View>
       </View>
     </SafeAreaView>

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -150,20 +150,35 @@ const ConfigEditor = ({config, handleConfigUpdate, style}: Props) => {
               <Text>No saved boards.</Text>
             )}
           </View>
-          <Button
-            color={Typography.colors.emerald}
-            title="Done"
-            onPress={() => {
-              setEditting(false);
-              handleConfigUpdate({
-                autoconnect: savedBoards.map(b => b.id),
-                debug,
-                speedUnit,
-                theme,
-                temperatureUnit,
-              });
-            }}
-          />
+          <View
+            style={{
+              borderBottomWidth: StyleSheet.hairlineWidth,
+              marginVertical: 20,
+            }}></View>
+          <View style={{flexDirection: 'row', justifyContent: 'flex-end'}}>
+            <Pressable
+              style={{
+                width: 75,
+                backgroundColor: Typography.colors.emerald,
+                paddingVertical: 10,
+                paddingHorizontal: 20,
+              }}
+              onPress={() => {
+                setEditting(false);
+                handleConfigUpdate({
+                  autoconnect: savedBoards.map(b => b.id),
+                  debug,
+                  speedUnit,
+                  theme,
+                  temperatureUnit,
+                });
+              }}>
+              <Text
+                style={{color: Typography.colors.white, textAlign: 'center'}}>
+                Done
+              </Text>
+            </Pressable>
+          </View>
         </SafeAreaView>
       </Modal>
     </View>
@@ -180,12 +195,12 @@ const styles = StyleSheet.create({
   selected: {
     backgroundColor: Typography.colors.emerald,
     color: Typography.colors.white,
-    paddingHorizontal: 10,
-    paddingVertical: 2.5,
+    paddingHorizontal: 15,
+    paddingVertical: 10,
   },
   deselected: {
-    paddingHorizontal: 10,
-    paddingVertical: 2.5,
+    paddingHorizontal: 15,
+    paddingVertical: 10,
   },
   optionRow: {
     flexDirection: 'row',

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -43,18 +43,7 @@ const ConfigEditor = ({config, handleConfigUpdate, style}: Props) => {
       <Pressable onPress={() => setEditting(true)}>
         <Text style={{fontSize: Typography.fontsize.xl}}>≡</Text>
       </Pressable>
-      <Modal
-        animationType="slide"
-        visible={editting}
-        onDismiss={() => {
-          handleConfigUpdate({
-            autoconnect: savedBoards.map(b => b.id),
-            debug,
-            speedUnit,
-            theme,
-            temperatureUnit,
-          });
-        }}>
+      <Modal animationType="slide" visible={editting}>
         <SafeAreaView style={styles.boxed}>
           <Text style={styles.h1}>User Options</Text>
           <View style={styles.optionRow}>
@@ -164,7 +153,16 @@ const ConfigEditor = ({config, handleConfigUpdate, style}: Props) => {
           <Button
             color={Typography.colors.emerald}
             title="Done"
-            onPress={() => setEditting(false)}
+            onPress={() => {
+              setEditting(false);
+              handleConfigUpdate({
+                autoconnect: savedBoards.map(b => b.id),
+                debug,
+                speedUnit,
+                theme,
+                temperatureUnit,
+              });
+            }}
           />
         </SafeAreaView>
       </Modal>

--- a/src/ModeSelection.tsx
+++ b/src/ModeSelection.tsx
@@ -1,12 +1,12 @@
 import React, {useEffect, useState} from 'react';
 
 import {Buffer} from '@craftzdog/react-native-buffer';
-import {Button, View} from 'react-native';
+import {Pressable, Text, View} from 'react-native';
 import BTManager, {PeripheralInfo} from 'react-native-ble-manager';
+import CustomShaping from './CustomShaping';
+import {Typography} from './Typography';
 import {CHARACTERISTICS, ONEWHEEL_SERVICE_UUID} from './util/bluetooth';
 import {inferBoardFromHardwareRevision} from './util/board';
-import {Typography} from './Typography';
-import CustomShaping from './CustomShaping';
 
 type SupportedBoards = 'XR' | 'Pint';
 
@@ -130,27 +130,56 @@ const ModeSelection = ({device, debug}: Props) => {
   // Render mode selection based on OW generation.
   return (
     <View>
-      {Object.entries(modes[boardType])
-        .filter(([modeName]) => (isShapingOpen ? modeName === 'custom' : true))
-        .map(([modeName, {symbol, value}]) => (
-          <Button
-            title={wrapIfSelected(
-              `${symbol} ${modeName[0].toUpperCase() + modeName.slice(1)}`,
-              value,
-            )}
-            key={modeName}
-            disabled={mode === value}
-            onPress={() => select(modeName).catch(err => console.error(err))}
-            color={Typography.colors.emerald}
-          />
-        ))}
+      <View
+        style={{
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}>
+        {Object.entries(modes[boardType])
+          .filter(([modeName]) =>
+            isShapingOpen ? modeName === 'custom' : true,
+          )
+          .map(([modeName, {symbol, value}]) => (
+            <Pressable
+              key={modeName}
+              disabled={mode === value}
+              onPress={() => select(modeName).catch(err => console.error(err))}>
+              <Text
+                style={{
+                  fontSize: Typography.fontsize.medium,
+                  color: mode === value ? 'grey' : Typography.colors.emerald,
+                  paddingVertical: 10,
+                  paddingHorizontal: 20,
+                  textAlign: 'center',
+                }}>
+                {wrapIfSelected(
+                  `${symbol} ${modeName[0].toUpperCase() + modeName.slice(1)}`,
+                  value,
+                )}
+              </Text>
+            </Pressable>
+          ))}
+      </View>
       {isShapingOpen && <CustomShaping device={device} />}
       {mode === 9 && (
-        <Button
-          title={isShapingOpen ? 'Close Shaping' : 'Open Shaping'}
-          color={Typography.colors.emerald}
-          onPress={() => setIsShapingOpen(!isShapingOpen)}
-        />
+        <Pressable
+          style={{
+            marginTop: 10,
+            backgroundColor: Typography.colors.emerald,
+            paddingVertical: 10,
+          }}
+          onPress={() => setIsShapingOpen(!isShapingOpen)}>
+          <Text
+            style={{
+              fontSize: Typography.fontsize.small,
+              color: Typography.colors.white,
+              textAlign: 'center',
+            }}>
+            {isShapingOpen ? 'Close Shaping' : 'Open Shaping'}
+          </Text>
+        </Pressable>
       )}
     </View>
   );

--- a/src/ShapingToggle.tsx
+++ b/src/ShapingToggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Button, Text, StyleSheet} from 'react-native';
+import {View, Text, StyleSheet, Pressable} from 'react-native';
 import {Typography} from './Typography';
 import {ShapingOptionName, ShapingOption} from './CustomShaping';
 
@@ -24,30 +24,46 @@ const ShapingToggle = ({option, value, handleModifier}: Props) => {
       <Text style={{marginVertical: 10}}>
         {option.emoji ?? option.name} : {value}
       </Text>
-      <View
-        style={{
-          ...style.button,
-          backgroundColor: option.colors.up,
-        }}>
-        <Button
-          disabled={value === option.limits.max}
-          color={Typography.colors.white}
-          title="＋"
-          onPress={() => handleModifier(option.name, option.limits.step)}
-        />
-      </View>
-      <View
-        style={{
-          ...style.button,
-          backgroundColor: option.colors.down,
-        }}>
-        <Button
-          disabled={value === option.limits.min}
-          color={Typography.colors.white}
-          title="−"
-          onPress={() => handleModifier(option.name, -1 * option.limits.step)}
-        />
-      </View>
+      <Pressable
+        style={({pressed}) => ({
+          width: '100%',
+          paddingVertical: 5,
+          backgroundColor:
+            pressed || value === option.limits.max
+              ? option.colors.label
+              : option.colors.up,
+        })}
+        disabled={value === option.limits.max}
+        onPress={() => handleModifier(option.name, option.limits.step)}>
+        <Text
+          style={{
+            color: Typography.colors.white,
+            textAlign: 'center',
+            fontSize: Typography.fontsize.medium,
+          }}>
+          ＋
+        </Text>
+      </Pressable>
+      <Pressable
+        style={({pressed}) => ({
+          width: '100%',
+          paddingVertical: 5,
+          backgroundColor:
+            pressed || value === option.limits.min
+              ? option.colors.label
+              : option.colors.down,
+        })}
+        disabled={value === option.limits.min}
+        onPress={() => handleModifier(option.name, -1 * option.limits.step)}>
+        <Text
+          style={{
+            color: Typography.colors.white,
+            textAlign: 'center',
+            fontSize: Typography.fontsize.medium,
+          }}>
+          −
+        </Text>
+      </Pressable>
     </View>
   );
 };


### PR DESCRIPTION
This PR comprises all of the styling and configuration changes that have to be done to fully support android.
As far as I can tell, most of the changes are abandoning the default `button` react native element in favour of the more consistent `pressable`.

This *should* also include README updates to make sure the project can be built/run on both the android sim and on an actual device.